### PR TITLE
[DDCI-780] - improved exception handling

### DIFF
--- a/ckanext/qdes_schema/helpers.py
+++ b/ckanext/qdes_schema/helpers.py
@@ -195,11 +195,12 @@ def get_related_object_or_url(context, resource):
     try:
         get_validator('package_id_exists')(resource_id, context)
         object_package_id = resource_id
-    except Invalid:
+    except Exception as e:
         # Dataset does not exist so must be an external dataset URL
         # Validation should have already happened in validator 'qdes_validate_related_dataset'
         # so the `resource` should be a URL to external dataset
         url = resource_id
+        log.error(str(e))
 
     return object_package_id, url
 


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-780

in this PR, 
- get_related_object_or_url has `resource` variable with value: `[{"resource": {"id": null}, "relationship": "Replaces"}]`
- the exception is not handling it well
- if there is an exception, `object_package_id, url` variables both will return None, 
- the parent function who call this function already have a check for this variables.
- so it won't break the save process.
