### PR TITLE
[DDCI-140] - added check for missing license_id

### DIFF
--- a/ckanext/qdes_schema/plugin.py
+++ b/ckanext/qdes_schema/plugin.py
@@ -259,6 +259,7 @@ class QDESSchemaPlugin(plugins.SingletonPlugin):
             'qdes_uri_validator': validators.qdes_uri_validator,
             'qdes_validate_decimal': validators.qdes_validate_decimal,
             'qdes_validate_decimal_positive': validators.qdes_validate_decimal_positive,
+            'qdes_validate_positive_integer': validators.qdes_validate_positive_integer,
             'qdes_validate_geojson': validators.qdes_validate_geojson,
             'qdes_validate_geojson_point': validators.qdes_validate_geojson_point,
             'qdes_validate_geojson_polygon': validators.qdes_validate_geojson_polygon,

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -741,7 +741,7 @@
       "label": "Size",
       "display_property": "dcat:byteSize",
       "display_snippet": "qdes_byte_size.html",
-      "validators": "ignore_missing int_validator is_positive_integer",
+      "validators": "ignore_missing qdes_validate_positive_integer",
       "form_placeholder": "Enter exact or approximate file size in bytes (integer)",
       "recommended": true
     },

--- a/ckanext/qdes_schema/templates/package/export/XML (ISO-19139).xml.j2
+++ b/ckanext/qdes_schema/templates/package/export/XML (ISO-19139).xml.j2
@@ -281,7 +281,7 @@
       <resourceConstraints>
         <MD_LegalConstraints>
           <useLimitation>
-            <gco:CharacterString>{{ dataset.get('license_id', {}).get('label') }}</gco:CharacterString>
+            <gco:CharacterString>{{ dataset.get('license_id', {}).get('label') if dataset.get('license_id') else '' }}</gco:CharacterString>
           </useLimitation>
           <useConstraints>
             <MD_RestrictionCode codeSpace="ISOTC211/19115" codeListValue="license" codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode">license</MD_RestrictionCode>
@@ -342,18 +342,18 @@
           </version>
         </MD_Format>
         {% if resource.get('compression') %}
-        <MD_CompressionFormat>
-          <name>
-            <gco:CharacterString>{{ resource.get('compression', {}).get('label') }}</gco:CharacterString>
-          </name>
-        </MD_CompressionFormat>
+          <MD_CompressionFormat>
+            <name>
+              <gco:CharacterString>{{ resource.get('compression', {}).get('label') }}</gco:CharacterString>
+            </name>
+          </MD_CompressionFormat>
         {% endif %}
         {% if resource.get('packaging') %}
-        <MD_CompressionFormat>
-          <name>
-            <gco:CharacterString>{{ resource.get('packaging', {}).get('label') }}</gco:CharacterString>
-          </name>
-        </MD_CompressionFormat>
+          <MD_CompressionFormat>
+            <name>
+              <gco:CharacterString>{{ resource.get('packaging', {}).get('label') }}</gco:CharacterString>
+            </name>
+          </MD_CompressionFormat>
         {% endif %}      
       </distributionFormat>
       {% endfor %}

--- a/ckanext/qdes_schema/validators.py
+++ b/ckanext/qdes_schema/validators.py
@@ -135,6 +135,12 @@ def qdes_validate_decimal_positive(value):
 
     return value
 
+def qdes_validate_positive_integer(value, context):
+    value = logic.validators.int_validator(value, context)
+
+    if value is not None and value < 1:
+        raise Invalid('Must be a positive integer')
+    return value
 
 def qdes_validate_geojson(value):
     """


### PR DESCRIPTION
https://it-partners.atlassian.net/browse/DDCI-140

I switched the `is_positive_integer` to custom validator, because if the value is `None`, it throws an error.
`qdes_validate_positive_integer` is similar as core `is_positive_integer`, except I added more check if `None`.