### PR TITLE
[SUPDESQ-22] Defects - The Other Responsible party field is no longer displaying the assigned name

### DIFF
--- a/ckanext/qdes_schema/templates/scheming/display_snippets/qdes_multi_group.html
+++ b/ckanext/qdes_schema/templates/scheming/display_snippets/qdes_multi_group.html
@@ -5,7 +5,8 @@
             {% set columns = (12 / field.get('field_group')|length)|int %}
             {% for field_group in field.get('field_group') or [] %}
                 <div class="col-xs-{{columns}}">
-                    {% if '/ckan-admin/vocabulary-services/secure-autocomplete/' in field_group.get('form_attrs', {}).get('data-module-source' ,'') %}
+                    {% if '/ckan-admin/vocabulary-services/secure-autocomplete/' in field_group.get('form_attrs', {}).get('data-module-source' ,'') 
+                       and 'alt=1' not in field_group.get('form_attrs', {}).get('data-module-source' ,'') %}
                         {% snippet "/scheming/display_snippets/qdes_secure_vocabulary_text.html", field=field_group , data=group_data %}
                     {% else %}
                         {% set value_data = group_data.get(field_group.field_name, '') %}


### PR DESCRIPTION
Update logic to only include snippet 'qdes_secure_vocabulary_text.html' if the alt_search_display parameter does not exist in the API URL