### PR TITLE
[SUPDESQ-47] moved loader to snippets

### DIFF
--- a/ckanext/qdes_schema/fanstatic/spinner.js
+++ b/ckanext/qdes_schema/fanstatic/spinner.js
@@ -1,12 +1,12 @@
 jQuery(document).ready(function () {
-    $('body').append('<div id="loadingDiv" class="spinner-border" role="status"> <span class="sr-only">Loading...</span></div>');
+    var $loaderEl = $('.loader');
     $(window).on('load', function () {
-        setTimeout(removeLoader, 2000); //wait for page load PLUS two seconds.
+        removeLoader();
     });
     function removeLoader() {
-        $("#loadingDiv").fadeOut(500, function () {
+        $loaderEl.fadeOut(500, function () {
             // fadeOut complete. Remove the loading div
-            $("#loadingDiv").remove(); //makes page more lightweight 
+            $loaderEl.remove(); //makes page more lightweight
         });
     }
 });

--- a/ckanext/qdes_schema/templates/package/edit_base.html
+++ b/ckanext/qdes_schema/templates/package/edit_base.html
@@ -4,3 +4,8 @@
     {% set button_text = _('View data service') if pkg.type == 'dataservice' else _('View dataset') %}
     {% link_for button_text, named_route=pkg.type ~ '.read', id=pkg.name, class_='btn btn-default', icon='eye' %}
 {% endblock %}
+
+{% block body_extras %}
+    {{ super() }}
+    {% snippet "snippets/loader.html" %}
+{% endblock %}

--- a/ckanext/qdes_schema/templates/package/resource_edit_base.html
+++ b/ckanext/qdes_schema/templates/package/resource_edit_base.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+{% block body_extras %}
+  {{ super() }}
+  {% snippet "snippets/loader.html" %}
+{% endblock %}

--- a/ckanext/qdes_schema/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/qdes_schema/templates/scheming/package/snippets/package_form.html
@@ -25,7 +25,6 @@
   {% asset 'qdes_schema/input-date-helper' %}
   {% asset 'qdes_schema/accordion' %}
   {% asset 'qdes_schema/style' %}
-   {% asset 'qdes_schema/spinner' %}
 
   {%- if not dataset_type -%}
     <p>

--- a/ckanext/qdes_schema/templates/scheming/package/snippets/resource_form.html
+++ b/ckanext/qdes_schema/templates/scheming/package/snippets/resource_form.html
@@ -25,7 +25,6 @@
   {% asset 'qdes_schema/repeating-fields' %}
   {% asset 'qdes_schema/autocomplete' %}
   {% asset 'qdes_schema/style' %}
-   {% asset 'qdes_schema/spinner' %}
 
   {%- if not dataset_type -%}
     <p>

--- a/ckanext/qdes_schema/templates/snippets/loader.html
+++ b/ckanext/qdes_schema/templates/snippets/loader.html
@@ -1,0 +1,11 @@
+{% set is_dataset_edit = True if g.controller == 'dataset' and g.action == 'edit' else False %}
+{% set is_dataservice_edit = True if g.controller == 'dataservice' and g.action == 'edit' else False %}
+{% set is_resource_edit = True if g.controller == 'resource' and g.action == 'edit' else False %}
+{% if is_dataset_edit or is_dataservice_edit or is_resource_edit %}
+  {% asset 'qdes_schema/spinner' %}
+  <div class="loader" role="status">
+    <div class="loader__spinner">
+      <span class="sr-only">Loading...</span>
+    </div>
+  </div>
+{% endif %}

--- a/ckanext/qdes_schema/templates/snippets/loader.html
+++ b/ckanext/qdes_schema/templates/snippets/loader.html
@@ -1,7 +1,9 @@
+{% set is_dataset_new = True if g.controller == 'qdes_schema' and g.action == 'new' else False %}
 {% set is_dataset_edit = True if g.controller == 'dataset' and g.action == 'edit' else False %}
-{% set is_dataservice_edit = True if g.controller == 'dataservice' and g.action == 'edit' else False %}
-{% set is_resource_edit = True if g.controller == 'resource' and g.action == 'edit' else False %}
-{% if is_dataset_edit or is_dataservice_edit or is_resource_edit %}
+{% set is_dataservice_new_edit = True if g.controller == 'dataservice' and (g.action == 'new' or g.action == 'edit') else False %}
+{% set is_resource_new_edit = True if g.controller == 'resource' and (g.action == 'new' or g.action == 'edit') else False %}
+{% set show_loader = is_dataset_new or is_dataset_edit or is_dataservice_new_edit or is_resource_new_edit %}
+{% if show_loader %}
   {% asset 'qdes_schema/spinner' %}
   <div class="loader" role="status">
     <div class="loader__spinner">


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/SUPDESQ-47

I have to refactor the js solution, the spinner was depending on the jquery.
the issue is, jquery or js file tends to load late,
I moved to use html instead, so we can get the html element before the jquery finish to load.

and use jquery to remove it once the load is finished.