### PR TITLE
[SUPDESQ-173] replaced deprecated attachment_filename parameter

### DIFF
--- a/ckanext/qdes_schema/blueprint.py
+++ b/ckanext/qdes_schema/blueprint.py
@@ -443,7 +443,7 @@ def dataset_export(id, format):
 
             return send_file(six.BytesIO(pretty_xml.encode('utf8')),
                              as_attachment=True,
-                             attachment_filename=f'{dataset.get("title")}.xml')
+                             download_name=f'{dataset.get("title")}.xml')
     except (NotFound, NotAuthorized):
         abort(404, _('Dataset not found'))
 


### PR DESCRIPTION
`attachment_filename` is deprecated in newer version, this is preventing the download metadata

![image](https://github.com/user-attachments/assets/5cd83d59-e4ef-4b2e-9ec9-400b5fca2160)
