### PR TITLE
[SUPDESQ-193] Active Directory Integration

### DIFF
--- a/ckanext/qdes_schema/assets/autocomplete.js
+++ b/ckanext/qdes_schema/assets/autocomplete.js
@@ -156,6 +156,9 @@ jQuery(document).ready(function () {
         if (source.indexOf('{vocabularyServiceName}') >= 0 && this.options.vocabularyServiceName.length > 0) {
           source = source.replace("{vocabularyServiceName}", this.options.vocabularyServiceName);
         }
+        if (source.indexOf('{orgId}') >= 0) {
+          source = source.replace("{orgId}", $("#field-organizations").val());
+        }
         var client = this.sandbox.client;
         var parseCompletions = this.parseCompletions;
         var options = {

--- a/ckanext/qdes_schema/qdes_ckan_dataset.json
+++ b/ckanext/qdes_schema/qdes_ckan_dataset.json
@@ -20,6 +20,13 @@
       "display_group": "general"
     },
     {
+      "field_name": "owner_org",
+      "label": "Organisation",
+      "preset": "dataset_organization",
+      "display_group": "general",
+      "form_placeholder": "Department of Environment and Science"
+    },
+    {
       "field_name": "identifiers",
       "label": "Identifier",
       "display_property": "dcterms:identifier",
@@ -672,7 +679,7 @@
       "form_placeholder": " ",
       "form_attrs": {
         "data-module": "qdes_autocomplete",
-        "data-module-source": "/ckan-admin/vocabulary-services/secure-autocomplete/{vocabularyServiceName}?alt=1&incomplete=?",
+        "data-module-source": "/ckan-admin/vocabulary-services/secure-autocomplete/{vocabularyServiceName}?alt=1&incomplete=?&org_id={orgId}",
         "data-module-key": "value",
         "data-module-label": "name",
         "data-module-minimum-input-length": 3,
@@ -727,7 +734,7 @@
       "form_placeholder": " ",
       "form_attrs": {
         "data-module": "qdes_autocomplete",
-        "data-module-source": "/ckan-admin/vocabulary-services/secure-autocomplete/{vocabularyServiceName}?alt=1&incomplete=?",
+        "data-module-source": "/ckan-admin/vocabulary-services/secure-autocomplete/{vocabularyServiceName}?alt=1&incomplete=?&org_id={orgId}",
         "data-module-key": "value",
         "data-module-label": "name",
         "data-module-minimum-input-length": 3,
@@ -754,7 +761,7 @@
           "form_placeholder": " ",
           "form_attrs": {
             "data-module": "qdes_autocomplete",
-            "data-module-source": "/ckan-admin/vocabulary-services/secure-autocomplete/{vocabularyServiceName}?alt=1&incomplete=?",
+            "data-module-source": "/ckan-admin/vocabulary-services/secure-autocomplete/{vocabularyServiceName}?alt=1&incomplete=?&org_id={orgId}",
             "data-module-key": "value",
             "data-module-label": "name",
             "data-module-minimum-input-length": 3,
@@ -916,13 +923,6 @@
       "display_group": "meta data life cycle",
       "validators": "ignore_missing url_validator qdes_uri_validator",
       "help_text": "If the metadata record was generated outside of the catalogue add the source where it originated from"
-    },
-    {
-      "field_name": "owner_org",
-      "label": "Organization",
-      "preset": "dataset_organization",
-      "display_group": "meta data life cycle",
-      "form_placeholder": "Department of Environment and Science"
     },
     {
       "field_name": "state",

--- a/ckanext/qdes_schema/qdes_presets.json
+++ b/ckanext/qdes_schema/qdes_presets.json
@@ -146,7 +146,7 @@
         "display_snippet": "qdes_multi_text.html",
         "form_attrs": {
           "data-module": "qdes_autocomplete",
-          "data-module-source": "/ckan-admin/vocabulary-services/secure-autocomplete/{vocabularyServiceName}?incomplete=?",
+          "data-module-source": "/ckan-admin/vocabulary-services/secure-autocomplete/{vocabularyServiceName}?incomplete=?&org_id={orgId}",
           "data-module-key": "value",
           "data-module-label": "name",
           "data-module-minimum-input-length": 3
@@ -160,7 +160,7 @@
         "display_snippet": "qdes_secure_vocabulary_text.html",
         "form_attrs": {
           "data-module": "qdes_autocomplete",
-          "data-module-source": "/ckan-admin/vocabulary-services/secure-autocomplete/{vocabularyServiceName}?incomplete=?",
+          "data-module-source": "/ckan-admin/vocabulary-services/secure-autocomplete/{vocabularyServiceName}?incomplete=?&org_id={orgId}",
           "data-module-key": "value",
           "data-module-label": "name",
           "data-module-minimum-input-length": 3

--- a/ckanext/qdes_schema/validators.py
+++ b/ckanext/qdes_schema/validators.py
@@ -1,16 +1,14 @@
 import ckan.lib.navl.dictization_functions as df
 import ckan.plugins.toolkit as toolkit
 import ckan.logic as logic
-import ckanext.qdes.logic.helpers.report_helpers as qdes_report_helpers
 import geojson
-import json
 import logging
 import re
 
 from datetime import datetime as dt
 from ckan.common import config
 from ckanext.scheming.validation import scheming_validator, scheming_choices
-from pprint import pformat
+
 
 log = logging.getLogger(__name__)
 get_action = logic.get_action
@@ -620,11 +618,13 @@ def qdes_validate_circular_replaces_relationships(current_dataset_id, relationsh
     return True
 
 
-def qdes_validate_point_of_contact(value, context):
+def qdes_validate_point_of_contact(key, flattened_data, errors, context):
     """
     Validates whether position id is in secure vocab or not.
     """
-    point_of_contact = qdes_report_helpers.get_point_of_contact(context, value)
+    value = flattened_data.get(key)
+    org_id = flattened_data.get(('owner_org',))
+    point_of_contact = get_action('get_secure_vocabulary_record')(context, {'vocabulary_name': 'point-of-contact', 'query': value, 'org_id': org_id})
     if not point_of_contact:
         raise toolkit.Invalid('Position ID is not found in secure vocabulary.')
 

--- a/ckanext/qdes_schema/validators.py
+++ b/ckanext/qdes_schema/validators.py
@@ -305,10 +305,10 @@ def qdes_iso_8601_durations(key, flattened_data, errors, context):
     # Validate the positive number of each value.
     try:
         result_period = re.split(
-            "(-)?P(?:([-.,\d]+)Y)?(?:([-.,\d]+)M)?(?:([-.,\d]+)W)?(?:([-.,\d]+)D)?",
+            r"(-)?P(?:([-.,\d]+)Y)?(?:([-.,\d]+)M)?(?:([-.,\d]+)W)?(?:([-.,\d]+)D)?",
             flattened_data[key])
 
-        result_time = re.split("T(?:([-.,\d]+)H)?(?:([-.,\d]+)M)?(?:([-.,\d]+)S)?", flattened_data[key])
+        result_time = re.split(r"T(?:([-.,\d]+)H)?(?:([-.,\d]+)M)?(?:([-.,\d]+)S)?", flattened_data[key])
 
         result = result_period + result_time
 
@@ -331,7 +331,7 @@ def qdes_iso_8601_durations(key, flattened_data, errors, context):
         raise toolkit.Invalid('The value in each field needs to be positive number.')
 
     # Validate the pattern.
-    result_pattern = re.split("^P(?=\d+[YMWD])(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d+[HMS])(\d+H)?(\d+M)?(\d+S)?)?$", flattened_data[key])
+    result_pattern = re.split(r"^P(?=\d+[YMWD])(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d+[HMS])(\d+H)?(\d+M)?(\d+S)?)?$", flattened_data[key])
     if len(result_pattern) <= 1:
         log.error(f'Invalid result_pattern: {result_pattern}')
         raise toolkit.Invalid('Incorrect ISO 8601 duration format')


### PR DESCRIPTION
This pull request introduces enhancements to the CKAN QDES schema extension, focusing on improving organization-based filtering, optimizing code, and refining validation logic. The most significant changes include adding support for organization-specific autocomplete functionality, refactoring code for better maintainability, and updating validation logic for secure vocabulary checks.

### Enhancements to Autocomplete Functionality:
* Updated `qdes_autocomplete` fields to include an `org_id` parameter in their `data-module-source` URLs to support organization-specific filtering in autocomplete functionality (`ckanext/qdes_schema/assets/autocomplete.js`, `ckanext/qdes_schema/qdes_ckan_dataset.json`, `ckanext/qdes_schema/qdes_presets.json`). [[1]](diffhunk://#diff-5eb564ca706804b9a01df5b5618772bec6a11526db75e8b2128bdf678844b074R159-R161) [[2]](diffhunk://#diff-91be20ae22300c3d03793f718be25d774a574e164b365ca065ad5d2058133b9cL675-R682) [[3]](diffhunk://#diff-91be20ae22300c3d03793f718be25d774a574e164b365ca065ad5d2058133b9cL730-R737) [[4]](diffhunk://#diff-91be20ae22300c3d03793f718be25d774a574e164b365ca065ad5d2058133b9cL757-R764) [[5]](diffhunk://#diff-0af79821728c5769e142edd8b0dfc6297762a09545c1de6cd4ecdfa099c53cdfL149-R149) [[6]](diffhunk://#diff-0af79821728c5769e142edd8b0dfc6297762a09545c1de6cd4ecdfa099c53cdfL163-R163)

### Code Refactoring:
* Reintroduced `request` from `toolkit` instead of directly importing it, simplifying imports and ensuring consistency (`ckanext/qdes_schema/plugin.py`). [[1]](diffhunk://#diff-5c6b33baa0c0031edc8f08c933f6dd910623558de04c60f95b2b18c727214198L7) [[2]](diffhunk://#diff-5c6b33baa0c0031edc8f08c933f6dd910623558de04c60f95b2b18c727214198R24)
* Removed unused imports like `pformat`, `qdes_report_helpers`, and `json` to clean up the codebase (`ckanext/qdes_schema/validators.py`).

### Validation Logic Updates:
* Updated the `qdes_validate_point_of_contact` function to include `org_id` when validating secure vocabulary records, ensuring organization-specific checks for position IDs (`ckanext/qdes_schema/validators.py`).

### Dataset Schema Adjustments:
* Added a new `owner_org` field to the dataset schema for better organization-related metadata handling, while removing a duplicate `owner_org` field from a different display group (`ckanext/qdes_schema/qdes_ckan_dataset.json`). [[1]](diffhunk://#diff-91be20ae22300c3d03793f718be25d774a574e164b365ca065ad5d2058133b9cR22-R28) [[2]](diffhunk://#diff-91be20ae22300c3d03793f718be25d774a574e164b365ca065ad5d2058133b9cL920-L926)

### Minor Fixes:
* Adjusted the logic for extracting temporal coverage parameters to use `request.args` instead of `request.params` for better compatibility (`ckanext/qdes_schema/plugin.py`).
* Removed trailing whitespace in the `clone_modify_dataset` method (`ckanext/qdes_schema/plugin.py`).